### PR TITLE
Update 顕,manifestar.yml Manifestar vs. Manifiesto

### DIFF
--- a/data/顕,manifestar.yml
+++ b/data/顕,manifestar.yml
@@ -1,5 +1,5 @@
 ﻿id: 顕
-clave: manifestar
+clave: Manifiesto
 historia: >-
   Te pasas todo el día haciendo fila (並) bajo el Sol (日), boca arriba. Al poco
   tiempo se manifiestan cosas en tu cabeza (頁) que no existen.


### PR DESCRIPTION
Aunque en esencia el significado es el mismo y es el sentido del kanji, en clase se dijo que este era el kanji para 'Manifiesto' no para 'Manifestar' (es que igual para el verbo se escribe de otro modo...)

Igualmente si está correcto, cierro la PR