### PR TITLE
Update 囲,encerrar.yml Encerrar vs. Rodear

### DIFF
--- a/data/囲,encerrar.yml
+++ b/data/囲,encerrar.yml
@@ -1,8 +1,8 @@
 ﻿id: 囲
-clave: encerrar
+clave: Rodear
 historia: >-
   Una de las peores muertes es caer en un pozo (井). Por eso, todos los pozos
-  tienen que estar encerrados (囗).
+  tienen que estar encerrados (囗), para ello se *rodean* de paredes.
 solo_componente: 0
 componentes:
   - encerrado


### PR DESCRIPTION
A este kanji, en la clase, se le dio el sentido de 'Rodear', precisamente para no confundirlo con 'Encerrar' , que igual lo entendí yo mal, lo menciono por si acaso. Si estuviese correcto, cerraría PR.

He añadido a la historia un detalle por si hubiese que corregirlo.