### PR TITLE
Update 粗,chapuza.yml Duplicado

### DIFF
--- a/data/粗,chapuza.yml
+++ b/data/粗,chapuza.yml
@@ -4,7 +4,6 @@ historia: >+
   Algo muy *burdo* para los japoneses, dado su respeto por el arroz (米),
   sería apilarlo en cualquier sitio sin tener en cuenta su importancia. 
 
-
   Cualquier cosa que no sea apilar el arroz en una estantería (且) resultaría muy *burdo*.
 
 componentes:


### PR DESCRIPTION
Lo he explicado, más o menos, en la pr anterior. Es posible que este kanji se haya dado de alta dos veces, primero como 'chapuza' (así sigue figurando en el itinerario de la base de datos, aunque había creado una pr hace como una semana para corregir el nombre) y después como 'burdo'. En la app ya ha desaparecido como 'chapuza' pero al introducir 'burdo' es curioso que salgan las dos descripciones.