### PR TITLE
feat:componentes-caminante-pala

### DIFF
--- a/data/亍,Caminante.yml
+++ b/data/亍,Caminante.yml
@@ -1,0 +1,11 @@
+﻿historia: >-
+  Para que el *caminante* pueda descansar durante su largo viaje, se detiene a
+  reparar el techo (一) de un refugio abandonado usando el único clavo (丁)  que
+  llevaba encima
+clave: Caminante
+id: 亍
+solo_componente: 1
+componentes:
+  - 'techo,一'
+  - 'clavo, 丁)'
+como_componente: []

--- a/data/凵,Pala.yml
+++ b/data/凵,Pala.yml
@@ -1,0 +1,8 @@
+﻿clave: Pala
+historia: >-
+  Este elemento envolvente es el pictograma de la hoja de una pala (凵), que
+  encierra a los componentes desde debajo.
+id: 凵
+solo_componente: 1
+componentes: []
+como_componente: []

--- a/data/行,Caminante.yml
+++ b/data/行,Caminante.yml
@@ -1,0 +1,12 @@
+﻿clave: Caminante
+id: 行
+historia: >-
+  Para que el *caminante* pueda descansar durante su largo viaje, se detiene a
+  reparar el techo (一) de un refugio abandonado, pero antes de usar el  clavo
+  (丁)  traza con cuidado una linea (彳) para no errar el golpe
+solo_componente: 1
+componentes:
+  - 'línea,彳'
+  - 'techo,一'
+  - 'clavo,丁'
+como_componente: []


### PR DESCRIPTION
He creado los componentes que se usaron ayer en algunas historias. Para caminante he creado dos versiones aunque tengo muy clara la mejor, que sería la más simple: 亍 (desde mi punto de vista, usar el mismo carácter para un componente y para un kanji puede no solo no favorecer la mnemotecnia sino inducir a error al usarlos, aunque se trate de una kanji tan básico como este)