### PR TITLE
feat: agregar kanji 零 (cero)

### DIFF
--- a/data/零,cero.yml
+++ b/data/零,cero.yml
@@ -1,7 +1,7 @@
 id: 零
 clave: cero
 historia: >
-  Bajo la lluvia, hasta las órdenes (令) se disuelven; de ahí surge el concepto de cero: nada queda ante lo inevitable.
+  Bajo la lluvia (雨), hasta las órdenes (令) se disuelven; de ahí surge el concepto de cero: nada queda ante lo inevitable.
 componentes:
   - lluvia
   - órdenes

--- a/data/零,cero.yml
+++ b/data/零,cero.yml
@@ -1,0 +1,9 @@
+id: 零
+clave: cero
+historia: >
+  Bajo la lluvia, hasta las órdenes (令) se disuelven; de ahí surge el concepto de cero: nada queda ante lo inevitable.
+componentes:
+  - lluvia
+  - órdenes
+como_componente: []
+solo_componente: 0


### PR DESCRIPTION
## Nuevo kanji agregado

- id: 零
- clave: cero
- historia: Bajo la lluvia(雨), hasta las órdenes (令) se disuelven; de ahí surge el concepto de cero: nada queda ante lo inevitable.
- componentes: lluvia, órdenes
- Validado siguiendo la constitución, definiciones, esquema y lifecycle de skills obligatorias.

Checklist lifecycle Kanji:
- [x] CONSTITUCION.md aplicada
- [x] DEFINICIONES.md respetada
- [x] RULES.md del paquete seguido
- [x] Skill validar-kanji aplicada
- [x] Validación YAML y schema

